### PR TITLE
PLACP-250 - add dot-fingers-core/detection/transformation podspecs

### DIFF
--- a/.github/workflows/dot-sdk_release.yml
+++ b/.github/workflows/dot-sdk_release.yml
@@ -120,7 +120,15 @@ jobs:
           sed -i "s/    s.ios.dependency 'dot-protobuf'.*$/    s.ios.dependency 'dot-protobuf', '$PROTOBUF_VERSION'/g" dot-palm-core_template.podspec
         env:
           PROTOBUF_VERSION: "${{github.event.client_payload.protobuf_version}}"
-                
+
+      - name: SHARED >> Update dot-protobuf dependency version for dot-fingers-core
+        if: github.event.client_payload.protobuf_version != ''
+        run: |
+          cd dot-fingers-core
+          sed -i "s/    s.ios.dependency 'dot-protobuf'.*$/    s.ios.dependency 'dot-protobuf', '$PROTOBUF_VERSION'/g" dot-fingers-core_template.podspec
+        env:
+          PROTOBUF_VERSION: "${{github.event.client_payload.protobuf_version}}"
+
 ###########################################################################################################################################
 
       - name: NFC >> Release openssl
@@ -195,9 +203,41 @@ jobs:
           sed -i "s/{version}/$RELEASE_VERSION/g" dot-palm-detection.podspec
         env:
           RELEASE_VERSION: "${{github.event.client_payload.release_version}}"
-      
+
 ###########################################################################################################################################
-      
+
+      - name: FINGERS >> Release dot-fingers-core
+        run: |
+          cd dot-fingers-core
+          mkdir $RELEASE_VERSION || true
+          cp -n dot-fingers-core_template.podspec $RELEASE_VERSION/dot-fingers-core.podspec || true
+          cd $RELEASE_VERSION
+          sed -i "s/{version}/$RELEASE_VERSION/g" dot-fingers-core.podspec
+        env:
+          RELEASE_VERSION: "${{github.event.client_payload.release_version}}"
+
+      - name: FINGERS >> Release dot-fingers-detection
+        run: |
+          cd dot-fingers-detection
+          mkdir $RELEASE_VERSION || true
+          cp -n dot-fingers-detection_template.podspec $RELEASE_VERSION/dot-fingers-detection.podspec || true
+          cd $RELEASE_VERSION
+          sed -i "s/{version}/$RELEASE_VERSION/g" dot-fingers-detection.podspec
+        env:
+          RELEASE_VERSION: "${{github.event.client_payload.release_version}}"
+
+      - name: FINGERS >> Release dot-fingers-transformation
+        run: |
+          cd dot-fingers-transformation
+          mkdir $RELEASE_VERSION || true
+          cp -n dot-fingers-transformation_template.podspec $RELEASE_VERSION/dot-fingers-transformation.podspec || true
+          cd $RELEASE_VERSION
+          sed -i "s/{version}/$RELEASE_VERSION/g" dot-fingers-transformation.podspec
+        env:
+          RELEASE_VERSION: "${{github.event.client_payload.release_version}}"
+
+###########################################################################################################################################
+
       - name: FACE >> Release onnx
         if: github.event.client_payload.iface_version != '' && github.event.client_payload.onnx_version != ''
         run: |

--- a/dot-fingers-core/dot-fingers-core_template.podspec
+++ b/dot-fingers-core/dot-fingers-core_template.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+    s.name              = 'dot-fingers-core'
+    s.version           = '{version}'
+    s.summary           = 'DOT iOS Fingers Core'
+    s.homepage          = 'https://www.innovatrics.com'
+
+    s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
+    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFingersCore/LICENSE' }
+
+
+    s.platform          = :ios
+    s.source            = { :http => "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-core/#{s.version}/DotFingersCore.zip" }
+    s.ios.deployment_target = '15.1'
+    s.ios.vendored_frameworks = 'DotFingersCore/DotFingersCore.xcframework'
+
+    s.ios.dependency 'dot-protobuf', '1.19.0'
+    s.ios.dependency 'dot-core', '{version}'
+    s.ios.dependency 'dot-serialization', '{version}'
+    s.ios.dependency 'dot-capture', '{version}'
+    s.ios.dependency 'dot-camera', '{version}'
+end
+
+# '0.1' exact version 0.1
+# '> 0.1' Any version higher than 0.1
+# '>= 0.1' Version 0.1 and any higher version
+# '< 0.1' Any version lower than 0.1
+# '<= 0.1' Version 0.1 and any lower version
+# '~> 0.1.2' Version 0.1.2 and the versions up to 0.2, not including 0.2 and higher
+# '~> 0.1' Version 0.1 and the versions up to 1.0, not including 1.0 and higher
+# '~> 0' Version 0 and higher, this is basically the same as not having it.

--- a/dot-fingers-detection/dot-fingers-detection_template.podspec
+++ b/dot-fingers-detection/dot-fingers-detection_template.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+    s.name              = 'dot-fingers-detection'
+    s.version           = '{version}'
+    s.summary           = 'DOT iOS Fingers Detection'
+    s.homepage          = 'https://www.innovatrics.com'
+
+    s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
+    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFingersDetection/LICENSE' }
+
+
+    s.platform          = :ios
+    s.source            = { :http => "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-detection/#{s.version}/DotFingersDetection.zip" }
+    s.ios.deployment_target = '15.1'
+    s.ios.vendored_frameworks = "DotFingersDetection/DotFingersDetection.xcframework"
+
+    s.ios.dependency 'dot-fingers-core', '{version}'
+end
+
+# '0.1' exact version 0.1
+# '> 0.1' Any version higher than 0.1
+# '>= 0.1' Version 0.1 and any higher version
+# '< 0.1' Any version lower than 0.1
+# '<= 0.1' Version 0.1 and any lower version
+# '~> 0.1.2' Version 0.1.2 and the versions up to 0.2, not including 0.2 and higher
+# '~> 0.1' Version 0.1 and the versions up to 1.0, not including 1.0 and higher
+# '~> 0' Version 0 and higher, this is basically the same as not having it.

--- a/dot-fingers-transformation/dot-fingers-transformation_template.podspec
+++ b/dot-fingers-transformation/dot-fingers-transformation_template.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+    s.name              = 'dot-fingers-transformation'
+    s.version           = '{version}'
+    s.summary           = 'DOT iOS Fingers Transformation'
+    s.homepage          = 'https://www.innovatrics.com'
+
+    s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
+    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFingersTransformation/LICENSE' }
+
+
+    s.platform          = :ios
+    s.source            = { :http => "https://s3.eu-central-1.amazonaws.com/ios-frameworks.innovatrics.com/dot-fingers-transformation/#{s.version}/DotFingersTransformation.zip" }
+    s.ios.deployment_target = '15.1'
+    s.ios.vendored_frameworks = "DotFingersTransformation/DotFingersTransformation.xcframework"
+
+    s.ios.dependency 'dot-fingers-core', '{version}'
+end
+
+# '0.1' exact version 0.1
+# '> 0.1' Any version higher than 0.1
+# '>= 0.1' Version 0.1 and any higher version
+# '< 0.1' Any version lower than 0.1
+# '<= 0.1' Version 0.1 and any lower version
+# '~> 0.1.2' Version 0.1.2 and the versions up to 0.2, not including 0.2 and higher
+# '~> 0.1' Version 0.1 and the versions up to 1.0, not including 1.0 and higher
+# '~> 0' Version 0 and higher, this is basically the same as not having it.


### PR DESCRIPTION
## What

Scaffolds the new **DotFingers** modules into the CocoaPods specs ahead of the public release.

- New podspec templates:
  - `dot-fingers-core/dot-fingers-core_template.podspec` — deps: `dot-protobuf 1.19.0`, `dot-core`, `dot-serialization`, `dot-capture`, `dot-camera`
  - `dot-fingers-detection/...` — dep: `dot-fingers-core`
  - `dot-fingers-transformation/...` — dep: `dot-fingers-core`
- `.github/workflows/dot-sdk_release.yml`:
  - protobuf-pin update step for `dot-fingers-core`
  - a `FINGERS` release section generating versioned podspecs for all three

## How it works

Scaffold only — the `dot_sdk_release` workflow fills the concrete `$RELEASE_VERSION` into per-version podspecs at release time, exactly like every other module. Must be merged to `master` before the SDK release pipeline dispatches the `podspecs` stage.

## Notes

- `deployment_target = 15.1` (DotFingers is built at iOS 15.1, not 13.0 like Palm/Face).
- `dot-fingers-core` is the shared dep of both detection and transformation (mirrors `dot-palm-core`).