### PR TITLE
PLACP-250 - rename DOT brand to IDV in podspec metadata

### DIFF
--- a/dot-camera/dot-camera_template.podspec
+++ b/dot-camera/dot-camera_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-camera'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Camera'
+    s.summary           = 'IDV iOS Camera'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotCamera/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotCamera/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-capture/dot-capture_template.podspec
+++ b/dot-capture/dot-capture_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-capture'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Capture'
+    s.summary           = 'IDV iOS Capture'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotCapture/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotCapture/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-core/dot-core_template.podspec
+++ b/dot-core/dot-core_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-core'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Core'
+    s.summary           = 'IDV iOS Core'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotCore/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotCore/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-document-barcode/dot-document-barcode_template.podspec
+++ b/dot-document-barcode/dot-document-barcode_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-document-barcode'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Document Barcode'
+    s.summary           = 'IDV iOS Document Barcode'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Marek Hrasna' => 'marek.hrasna@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotDocumentBarcode/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotDocumentBarcode/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-document-commons/dot-document-commons_template.podspec
+++ b/dot-document-commons/dot-document-commons_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-document-commons'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Document Commons'
+    s.summary           = 'IDV iOS Document Commons'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotDocumentCommons/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotDocumentCommons/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-document/dot-document_template.podspec
+++ b/dot-document/dot-document_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-document'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Document'
+    s.summary           = 'IDV iOS Document'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotDocument/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotDocument/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-background-uniformity/dot-face-background-uniformity_template.podspec
+++ b/dot-face-background-uniformity/dot-face-background-uniformity_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-background-uniformity'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Background Uniformity'
+    s.summary           = 'IDV iOS Face Background Uniformity'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceBackgroundUniformity/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceBackgroundUniformity/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-commons/dot-face-commons_template.podspec
+++ b/dot-face-commons/dot-face-commons_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-commons'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Commons'
+    s.summary           = 'IDV iOS Face Commons'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceCommons/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceCommons/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-core/dot-face-core_template.podspec
+++ b/dot-face-core/dot-face-core_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-core'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Core'
+    s.summary           = 'IDV iOS Face Core'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceCore/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceCore/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-detection-balanced/dot-face-detection-balanced_template.podspec
+++ b/dot-face-detection-balanced/dot-face-detection-balanced_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-detection-balanced'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Detection Balanced'
+    s.summary           = 'IDV iOS Face Detection Balanced'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceDetectionBalanced/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceDetectionBalanced/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-detection-fast/dot-face-detection-fast_template.podspec
+++ b/dot-face-detection-fast/dot-face-detection-fast_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-detection-fast'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Detection Fast'
+    s.summary           = 'IDV iOS Face Detection Fast'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceDetectionFast/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceDetectionFast/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-detection/dot-face-detection_template.podspec
+++ b/dot-face-detection/dot-face-detection_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-detection'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Detection'
+    s.summary           = 'IDV iOS Face Detection'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceDetection/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceDetection/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-expression-neutral/dot-face-expression-neutral_template.podspec
+++ b/dot-face-expression-neutral/dot-face-expression-neutral_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-expression-neutral'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Expression Neutral'
+    s.summary           = 'IDV iOS Face Expression Neutral'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceExpressionNeutral/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceExpressionNeutral/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-eye-gaze-liveness/dot-face-eye-gaze-liveness_template.podspec
+++ b/dot-face-eye-gaze-liveness/dot-face-eye-gaze-liveness_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-eye-gaze-liveness'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Eye Gaze Liveness'
+    s.summary           = 'IDV iOS Face Eye Gaze Liveness'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceEyeGazeLiveness/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceEyeGazeLiveness/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-lite/dot-face-lite_template.podspec
+++ b/dot-face-lite/dot-face-lite_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-lite'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Lite'
+    s.summary           = 'IDV iOS Face Lite'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceLite/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceLite/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-passive-liveness/dot-face-passive-liveness_template.podspec
+++ b/dot-face-passive-liveness/dot-face-passive-liveness_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-passive-liveness'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Passive Liveness'
+    s.summary           = 'IDV iOS Face Passive Liveness'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFacePassiveLiveness/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFacePassiveLiveness/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face-verification/dot-face-verification_template.podspec
+++ b/dot-face-verification/dot-face-verification_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face-verification'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Face Verification'
+    s.summary           = 'IDV iOS Face Verification'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFaceVerification/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFaceVerification/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-face/dot-face_template.podspec
+++ b/dot-face/dot-face_template.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-face'
     s.version           = '{version}'
-    s.summary           = 'DOT Facial Recognition Framework'
+    s.summary           = 'IDV Facial Recognition Framework'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }

--- a/dot-fingers-core/dot-fingers-core_template.podspec
+++ b/dot-fingers-core/dot-fingers-core_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-fingers-core'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Fingers Core'
+    s.summary           = 'IDV iOS Fingers Core'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFingersCore/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFingersCore/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-fingers-detection/dot-fingers-detection_template.podspec
+++ b/dot-fingers-detection/dot-fingers-detection_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-fingers-detection'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Fingers Detection'
+    s.summary           = 'IDV iOS Fingers Detection'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFingersDetection/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFingersDetection/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-fingers-transformation/dot-fingers-transformation_template.podspec
+++ b/dot-fingers-transformation/dot-fingers-transformation_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-fingers-transformation'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Fingers Transformation'
+    s.summary           = 'IDV iOS Fingers Transformation'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotFingersTransformation/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotFingersTransformation/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-nfc/dot-nfc_template.podspec
+++ b/dot-nfc/dot-nfc_template.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-nfc'
     s.version           = '{version}'
-    s.summary           = 'DOT NFC framework'
+    s.summary           = 'IDV NFC framework'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }

--- a/dot-palm-core/dot-palm-core_template.podspec
+++ b/dot-palm-core/dot-palm-core_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-palm-core'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Palm Core'
+    s.summary           = 'IDV iOS Palm Core'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotPalmCore/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotPalmCore/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-palm-detection/dot-palm-detection_template.podspec
+++ b/dot-palm-detection/dot-palm-detection_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-palm-detection'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Palm Detection'
+    s.summary           = 'IDV iOS Palm Detection'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotPalmDetection/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotPalmDetection/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-protobuf/dot-protobuf_template.podspec
+++ b/dot-protobuf/dot-protobuf_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-protobuf'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Protocol Buffers'
+    s.summary           = 'IDV iOS Protocol Buffers'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotProtocolBuffers/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotProtocolBuffers/LICENSE' }
 
 
     s.platform          = :ios

--- a/dot-serialization/dot-serialization_template.podspec
+++ b/dot-serialization/dot-serialization_template.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
     s.name              = 'dot-serialization'
     s.version           = '{version}'
-    s.summary           = 'DOT iOS Serialization'
+    s.summary           = 'IDV iOS Serialization'
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'DotSerialization/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'DotSerialization/LICENSE' }
 
 
     s.platform          = :ios

--- a/iface/iface_template.podspec
+++ b/iface/iface_template.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'IFace/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'IFace/LICENSE' }
 
 
     s.platform          = :ios

--- a/onnx/onnx_template.podspec
+++ b/onnx/onnx_template.podspec
@@ -5,7 +5,7 @@ Pod::Spec.new do |s|
     s.homepage          = 'https://www.innovatrics.com'
 
     s.author            = { 'Jakub Vallo' => 'jakub.vallo@innovatrics.com' }
-    s.license           = { :type => 'Innovatrics DOT License', :file => 'Onnx/LICENSE' }
+    s.license           = { :type => 'Innovatrics IDV License', :file => 'Onnx/LICENSE' }
 
 
     s.platform          = :ios


### PR DESCRIPTION
Rename the DOT product name to IDV in podspec publish metadata across all module templates (`s.summary`, `s.license :type`), matching the SDK rebrand (PLACP-250) and the Android PLACP-217 POM metadata change. Pod names, license file paths, dependencies and S3 URLs are unchanged.